### PR TITLE
Change the last slot of the day

### DIFF
--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -128,6 +128,14 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
       if (!ignoreMin) rangeStart = dates.min(end, dates.max(start, rangeStart))
       if (!ignoreMax) rangeEnd = dates.min(end, dates.max(start, rangeEnd))
 
+      if (dates.minutes(rangeEnd) === 59) {
+        rangeEnd = dates.subtract(
+          dates.min(end, dates.max(start, rangeEnd)),
+          4,
+          'minutes'
+        )
+      }
+
       const rangeStartMin = positionFromDate(rangeStart)
       const rangeEndMin = positionFromDate(rangeEnd)
       const top =

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -17,6 +17,7 @@ export {
   lt,
   inRange,
   min,
+  subtract,
   max,
 } from 'date-arithmetic'
 


### PR DESCRIPTION
In our systems, we only support creating events ending at 11:55pm. To accurately display and show that, we made a change for the final timeslot of the day.