### PR TITLE
Allow the system to work with 15 minute instances

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -194,7 +194,7 @@ class DayColumn extends React.Component {
       events,
       accessors,
       slotMetrics,
-      minimumStartDifference: Math.ceil((step * timeslots) / 2),
+      minimumStartDifference: Math.ceil((step * timeslots) / 4),
       dayLayoutAlgorithm,
     })
 

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -138,10 +138,7 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
 
       const rangeStartMin = positionFromDate(rangeStart)
       const rangeEndMin = positionFromDate(rangeEnd)
-      const top =
-        rangeEndMin - rangeStartMin < step && !dates.eq(end, rangeEnd)
-          ? ((rangeStartMin - step) / (step * numSlots)) * 100
-          : (rangeStartMin / (step * numSlots)) * 100
+      const top = (rangeStartMin / (step * numSlots)) * 100
 
       return {
         top,


### PR DESCRIPTION
This now makes the top of the event be proper each time and also allows for a 15 minute event height to show up correctly.